### PR TITLE
Fix name of the list in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Support for blocking mode with `BLPOP` is not supported yet.
 
 ### Centralized Logging
 
-In this sample we pipe the syslog to a Redis List called `log`.
+In this sample we pipe the syslog to a Redis List called `logs`.
 
 ```
 tail -f /var/log/syslog | ./redis-pipe logs
@@ -62,7 +62,7 @@ on a single server.
 Create jobs and store them.
 
 ```
-cat jobs.txt | redis-pipe jobs
+cat jobs.txt | ./redis-pipe jobs
 ```
 
 Process jobs on several workers and store the results.


### PR DESCRIPTION
Hi @lukasmartinelli,

Man! this is a nice hack, love this. :zap: 

The PR contains a tiny fix in the example you have written in the README file.
The name of the list was wrong there, _log_ instead of _logs_.

And I have also noticed that while running the build, you have used _./redis-pipe_ instead of _redis-pipe_ at all places except one, so I changed that too.

I hope you won't laugh at this tiny thing and me.
I just could not stop myself from doing this. :smile: 
