### PR TITLE
s/stout/stdout

### DIFF
--- a/redis-pipe.go
+++ b/redis-pipe.go
@@ -75,7 +75,7 @@ func write(list string, conn redis.Conn) {
 func main() {
 	app := cli.NewApp()
 	app.Name = "redis-pipe"
-	app.Usage = "connect stdin with LPUSH and LPOP with stout."
+	app.Usage = "connect stdin with LPUSH and LPOP with stdout."
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "host",


### PR DESCRIPTION
This fixes a small typo in the help text.
